### PR TITLE
Bugfixes for icx

### DIFF
--- a/fvgcm/CMakeLists.txt
+++ b/fvgcm/CMakeLists.txt
@@ -22,7 +22,7 @@ add_dependencies (${this} fvgcm_inc)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 if (EXTENDED_SOURCE)
-  set_target_properties (${this} PROPERTIES COMPILE_FLAGS ${EXTENDED_SOURCE})
+  target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${EXTENDED_SOURCE}>)
 endif()
 
 

--- a/svec/CMakeLists.txt
+++ b/svec/CMakeLists.txt
@@ -46,7 +46,7 @@ ecbuild_add_executable(TARGET simsv.x SOURCES simsv.f90 LIBS ${this})
 ecbuild_add_executable(TARGET svspectra.x SOURCES svspectra.f90 LIBS ${this})
 
 if (EXTENDED_SOURCE)
-  set_target_properties (${this} PROPERTIES COMPILE_FLAGS ${EXTENDED_SOURCE})
+  target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${EXTENDED_SOURCE}>)
 endif()
 
 target_compile_definitions (${this} PRIVATE REAL8 LSMH_off VERSION=\"fvgcm\")


### PR DESCRIPTION
GEOSgcm (and thus GEOSadas) will soon move to use Intel ifort 2021.13. With this comes the `icx` C compiler. Testing showed that some of the CMake was a bit loose and, for Intel, was applying `-extend-source` to not just Fortran files, but also *C* files. This is not a C flag (for `icx`) so we need to update the CMake to fix that.